### PR TITLE
Adds new "na2ts" tool

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,7 @@ CFLAGS =-O2 -Wall
 OBJS_EDI2ETI = network.o af_parser.o pf_parser.o tag_parser.o crc.o eti_assembler.o logging.o edi2eti.o
 OBJS_TS2NA = ts2na.o
 OBJS_TS2NA_DREAMBOX = ts2na.o tune.o
+OBJS_NA2TS = na2ts.o
 OBJS_NA2NI = na2ni.o
 OBJS_NI2HTTP = ni2http.o wffigproc.o wfficproc.o wfbyteops.o wftables.o wffirecrc.o wfcrc.o parse_config.o
 CFLAGS+=-I. -Ilibshout-2.2.2/include
@@ -19,11 +20,11 @@ LDFLAGS+= -lzmq
 ##################################################
 # Uncomment this 2 lines if you want to enable FEC
 ##################################################
-CFLAGS+= -DHAVE_FEC
-LDFLAGS+= -lfec
+#CFLAGS+= -DHAVE_FEC
+#LDFLAGS+= -lfec
 
 
-all: cleanapps ni2http  ts2na na2ni edi2eti
+all: cleanapps ni2http  ts2na na2ts na2ni edi2eti
 
 %.o: %.c
 	$(CC) $(CFLAGS) -c -o $@ $<
@@ -37,6 +38,9 @@ ts2na: $(OBJS_TS2NA)
 ts2na_dreambox: $(OBJS_TS2NA_DREAMBOX)
 	$(CC) -o $@ $(OBJS_TS2NA_DREAMBOX) $(LDFLAGS)
 
+na2ts: $(OBJS_NA2TS)
+	$(CC) -o $@ $(OBJS_NA2TS) $(LDFLAGS)
+
 na2ni: $(OBJS_NA2NI)
 	$(CC) -o $@ $(OBJS_NA2NI) $(LDFLAGS)
 
@@ -48,7 +52,7 @@ libshout-2.2.2/src/.libs/libshout.a:
 
 cleanapps:
 	rm -f $(OBJS_EDI2ETI) $(OBJS_TS2NA) $(OBJS_TS2NA_DREAMBOX) $(OBJS_NA2NI) $(OBJS_NI2HTTP)
-	rm -f ts2na na2ni ni2http edi2eti
+	rm -f ts2na na2ts na2ni ni2http edi2eti
 
 clean: cleanapps
 	if [ -f ./libshout-2.2.2/src/.libs/libshout.a ]; then cd libshout-2.2.2; make clean; cd ..;  fi;

--- a/na2ts.c
+++ b/na2ts.c
@@ -1,0 +1,126 @@
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <stdint.h>
+#include <string.h>
+#include <getopt.h>
+#include "ts.h"
+
+#define DEBUG(format, ...) fprintf (stderr, "DEBUG: "format"\n", ## __VA_ARGS__)
+#define  INFO(format, ...) fprintf (stderr, "INFO:  "format"\n", ## __VA_ARGS__)
+#define WARN(format, ...)  fprintf (stderr, "WARN:  "format"\n", ## __VA_ARGS__)
+#define ERROR(format, ...) fprintf (stderr, "ERROR: "format"\n", ## __VA_ARGS__)
+
+
+/*****************************************************************************
+ * Main loop
+ *****************************************************************************/
+static void usage(const char *psz)
+{
+    fprintf(stderr, "usage: %s [-p pid] [-s offset] [-i <inputfile>] [-o <outputfile>]\n", psz);
+    exit(EXIT_FAILURE);
+}
+
+int main(int i_argc, char **ppsz_argv)
+{
+    int c;
+    FILE *inputfile=stdin;
+    FILE *outputfile=stdout;
+    int offset=12, pid=0x0;
+    int i_last_cc = -1;
+
+    static const struct option long_options[] = {
+        { "pid",           required_argument,  NULL, 'p' },
+        { "offset (-3:only TS-sync byte; 12:pid mode)", required_argument, NULL, 's' },
+        { "input",         required_argument,  NULL, 'i' },
+        { "output",        required_argument,  NULL, 'o' },
+        { 0, 0, 0, 0 }
+    };
+
+    while ((c = getopt_long(i_argc, ppsz_argv, "p:s:i:o:h", long_options, NULL)) != -1)
+    {
+        switch (c) {
+        case 'p':
+            pid=strtoul(optarg, NULL, 0);
+            if(pid >= 8192) {
+                ERROR("bad pid value: %d!", pid);
+                exit(1);
+            }
+            break;
+
+        case 's':
+            offset=strtol(optarg, NULL, 0);
+            if(offset != -3 && offset != 12) {
+                ERROR("bad offset value: %d!", offset);
+                exit(1);
+            }
+            break;
+
+        case 'i':
+            inputfile = fopen(optarg, "r");
+            if(!inputfile) {
+                ERROR("cant open input file!");
+                exit(1);
+            }
+            break;
+
+        case 'o':
+            outputfile = fopen(optarg, "w");
+            if(!outputfile) {
+                ERROR("cant open output file!");
+                exit(1);
+            }
+            break;
+
+
+        case 'h':
+        default:
+            usage(ppsz_argv[0]);
+        }
+    }
+
+
+    if (offset == -3) {
+      INFO("Encapsulation mode: only 0x47 TS-Sync byte at each 188 bytes");
+      pid = 0;
+    } else if (offset == 12) {
+      INFO("Encapsulation mode: payload over pid 0x%04x (%d)", pid, pid);
+    }
+    offset += 4;
+    unsigned long int packets=0;
+    while (!feof(inputfile) && !ferror(inputfile)) {
+        uint8_t p_ts[TS_SIZE];
+        if (offset == 1) {
+                p_ts[0] = 0x47;
+        } else {
+                ts_pad(p_ts);
+        }
+        size_t i_ret = fread(p_ts+offset, TS_SIZE - offset, 1, inputfile);
+        if (i_ret != 1) {
+        	WARN("Can't read input ts");
+        	break;
+        }
+
+        if(offset >= 16) {
+                ts_set_pid(p_ts, pid);
+                ts_set_cc(p_ts, ++i_last_cc);
+        }
+
+      	size_t o_ret = fwrite(p_ts, TS_SIZE, 1, outputfile);
+        if (o_ret != 1) {
+       	        WARN("Can't write output ts");
+       	        break;
+        }
+        packets++;
+    }
+
+    if(packets){
+    	INFO("Successfully writed %ld ts-packets", packets);
+    }
+
+
+//mainErr:
+    fclose(inputfile);
+    fclose(outputfile);
+    return 0;
+}


### PR DESCRIPTION
This patch adds the tool "na2ts". This new tool is the reverse version of the current "ts2na".

It uses the same parameters (for convenience). But it only supports "-s" values "-3" and "12". These two values have a full correspondence with the "ts2na".

The value "-3" only adds a simple 0x47 TS-Sync byte at the start of each 188 bytes.

In contrast, the value "12" does a real pid encapsulation using the pid number indicated. However, the resulting TS doesn't have any PCR values. So, if you like to mux it in a real MPEG-TS it will be convenient to indicate a fixed 2Mbps (2048 Kbps) bitrate to the muxer.

Note: After an analisys of different sat feeds with "-s 12" these MPEG-TS also have a missing PCR. So, I don't found any reason to add complexity to the code adding it. However, if you need it, you can add the timestamp marks without troubles as the TS Header is clean, and it doesn't touch the Payload (ETI-NA bitstream). You can do this with an external tool indicating the bitrate (2Mbps).
