### PR TITLE
TS2NI: handle ts packets with errors

### DIFF
--- a/ts2na.c
+++ b/ts2na.c
@@ -95,7 +95,13 @@ int main(int i_argc, char **ppsz_argv)
             		WARN("TS Discontinuity");
             	}
             	i_last_cc = ts_get_cc(p_ts);
-            	uint8_t *payload = ts_payload(p_ts);
+            	uint8_t *payload;
+                if(ts_get_transporterror(p_ts)) {
+                        WARN("TS Packed error!");
+                        payload = p_ts + TS_HEADER_SIZE;  // When error is detected, pass the entire payload.
+                } else {
+                        payload = ts_payload(p_ts);
+                }
             	if(offset) {
             		payload+=offset;
             	}


### PR DESCRIPTION
This patch incorporates a handle when the ts packet has an error.

In this particular case, when the packet is marked with errors by the demodulator (and only in this case, that is when the error bit is set), the rest of the TS header is invalid. So, the best behaviour is pass the entire payload to the output. Upper layers then can use FEC or other techniques to process the data.

Without this patch the process will exit at any time when it reads some incorrect TS header (usually when the ts_payload() function returns an incorrect value). So the patch is required when using not 100% clean inputs.
