### PR TITLE
ni2http: add new parameter sid

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ ETI-NI streams from terrestrial DAB ensembles can also be created by [eti-stuff]
 
     usage: ./ni2http [--list] [--delay] [-i <inputfile>] [-c <config_file>] [-s <SID>]
 
-Use `--list` option to find SIDs and station names of the streams inside ETI. If you wish to write stream to stdout, then use `ni2http --sid <SID>`.
+Use `--list` option to find SIDs and station names of the streams inside ETI. If you wish to write stream to stdout, then use `ni2http --sid <SID>`. In this case the config_file isn't needed.
 The `--delay` option has to be used for offline-relaying (from the file, not from the stream). So in that case application will wait 24ms after each eti frame in order to make pseudo-realtime streaming.
 
 The application is also able to parse FIC for auto-detecting of station name and X-PAD of DAB and DAB+ for setting current DLS (song titles).

--- a/README.md
+++ b/README.md
@@ -85,9 +85,9 @@ ETI ni2http
 
 ETI-NI streams from terrestrial DAB ensembles can also be created by [eti-stuff](https://github.com/JvanKatwijk/eti-stuff) or [dabtools](https://github.com/Opendigitalradio/dabtools). For satellite feeds see above.
 
-    usage: ./ni2http [--list] [--delay] [-i <inputfile>] [-c <config_file>]
+    usage: ./ni2http [--list] [--delay] [-i <inputfile>] [-c <config_file>] [-s <SID>]
 
-Use `--list` option to find SIDs and station names of the streams inside ETI.
+Use `--list` option to find SIDs and station names of the streams inside ETI. If you wish to write stream to stdout, then use `ni2http --sid <SID>`.
 The `--delay` option has to be used for offline-relaying (from the file, not from the stream). So in that case application will wait 24ms after each eti frame in order to make pseudo-realtime streaming.
 
 The application is also able to parse FIC for auto-detecting of station name and X-PAD of DAB and DAB+ for setting current DLS (song titles).


### PR DESCRIPTION
The new parameter allows to write stream of SID to stdout without the need of config.
It's very usefull for constructing pipelines that feed data directly to a player.