### PR TITLE
Check ADTS frame len and UDP frame len match to stop invalid data output

### DIFF
--- a/mpe2aac.c
+++ b/mpe2aac.c
@@ -306,8 +306,15 @@ void callback(mpegts_psi_t *psi)
     }
 
     /* when aac located successfully */
-    if (len_udp > 8)
-        fwrite(payload, 1, len_udp, stdout);
+    if (len_udp > 8) {
+        /* get AAC frame length as reported by the ADTS packet itself */
+        int aac_frame_len = ((payload[3] & 0x3) << 11) | ((payload[4] << 3) | (payload[5] >> 5));
+
+        /* Only output AAC frames with matching length in ADTS packet to avoid FFMPEG errors */
+        if (len_udp == aac_frame_len) {
+            fwrite(payload, 1, len_udp, stdout);
+        }
+    }
 
 }
 


### PR DESCRIPTION
Some packets with the correct header (0xFF 0xF9/0xFF 0xF1) aren't actually valid AAC ADTS frames in some streams (e.g. Hispasat 30W 12518H). We can filter these by checking that the UDP packet length for the payload (minus headers) matches the  packet length as reported in the ADTS frames itself.

The invalid ADTS frames have super long length values (e.g. 7831 bytes), which doesn't match the spec (max frame length 768 bytes), so these seem safe to drop. I don't know what these invalid frames are and what purpose they serve, but I've tested this fix with the Hispasat streams and the output AAC data is glitch-free and plays perfectly.

Fixes #36 